### PR TITLE
Speed up startup by improvment chown execution strategy

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -5,7 +5,7 @@ procs=$(cat /proc/cpuinfo | grep processor | wc -l)
 sed -i -e "s/worker_processes  1/worker_processes $procs/" /etc/nginx/nginx.conf
 
 # Always chown webroot for better mounting
-chown -Rf nginx:nginx /usr/share/nginx/html
+RUN find /usr/share/nginx/html -not -user nginx -execdir chown nginx:nginx {} \+
 
 # Start supervisord and services
 /usr/local/bin/supervisord -n -c /etc/supervisord.conf


### PR DESCRIPTION
My container was starting more then 1 minute even if I made sure that my files have correct owner.

I realized that this is due to chown  inefficiency (https://unix.stackexchange.com/a/245275/11561) 